### PR TITLE
Endpoint macro

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -8,6 +8,15 @@ To install from Hex, run:
 
     $ mix archive.install hex sleeky_new
 
+To build and install it locally, ensure any previous archive versions are removed:
+
+    $ mix archive.uninstall sleeky_new
+
+Then run:
+
+    $ cd installer
+    $ MIX_ENV=prod mix do archive.build, archive.install
+
 ## Usage
 
 Create a new `sleeky` project with:

--- a/installer/lib/mix/tasks/new.ex
+++ b/installer/lib/mix/tasks/new.ex
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Sleeky.New do
     create_file("lib/#{mod_filename}/application.ex", lib_app_template(assigns))
     create_file("lib/#{mod_filename}/repo.ex", lib_repo_template(assigns))
     create_file("lib/#{mod_filename}/auth.ex", lib_auth_template(assigns))
-    create_file("lib/#{mod_filename}/port.ex", lib_port_template(assigns))
+    create_file("lib/#{mod_filename}/endpoint.ex", lib_endpoint_template(assigns))
     create_file("lib/#{mod_filename}/router.ex", lib_router_template(assigns))
     create_file("lib/#{mod_filename}/put_user.ex", lib_put_user_template(assigns))
     create_file("lib/#{mod_filename}/rest.ex", lib_rest_template(assigns))
@@ -381,7 +381,7 @@ defmodule Mix.Tasks.Sleeky.New do
     def start(_type, _args) do
       children = [
         <%= @mod %>.Repo,
-        <%= @mod %>.Port
+        <%= @mod %>.Endpoint
       ]
 
       opts = [strategy: :one_for_one, name: <%= @mod %>.Supervisor]
@@ -414,19 +414,10 @@ defmodule Mix.Tasks.Sleeky.New do
   end
   """)
 
-  embed_template(:lib_port, """
-  defmodule <%= @mod %>.Port do
+  embed_template(:lib_endpoint, """
+  defmodule <%= @mod %>.Endpoint do
     @moduledoc false
-
-    def child_spec(_) do
-      Supervisor.child_spec(
-        {Bandit,
-         :<%= @app %>
-         |> Application.fetch_env!(__MODULE__)
-         |> Keyword.put(:plug, <%= @mod %>.Router)},
-        []
-      )
-    end
+    use Sleeky.Endpoint, otp_app: :<%= @app %>, router: <%= @mod %>.Router
   end
   """)
 
@@ -588,7 +579,7 @@ defmodule Mix.Tasks.Sleeky.New do
       url: System.fetch_env!("DATABASE_URL"),
       pool_size: "DATABASE_POOL_SIZE" |> System.fetch_env!() |> String.to_integer()
 
-    config :<%= @app %>, <%= @mod %>.Port,
+    config :<%= @app %>, <%= @mod %>.Endpoint,
       scheme: :http,
       port: "PORT" |> System.fetch_env!() |> String.to_integer()
   end

--- a/installer/lib/mix/tasks/new.ex
+++ b/installer/lib/mix/tasks/new.ex
@@ -351,7 +351,7 @@ defmodule Mix.Tasks.Sleeky.New do
         {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
         {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
         {:excoveralls, "~> 0.14", only: [:test]},
-        {:sleeky, "~> 0.0.1"}
+        {:sleeky, git: "https://github.com/pedro-gutierrez/sleeky.git"}
       ]
     end
   end

--- a/lib/sleeky/endpoint.ex
+++ b/lib/sleeky/endpoint.ex
@@ -1,0 +1,41 @@
+defmodule Sleeky.Endpoint do
+  @moduledoc """
+  A simple helper macro that sets up a bandit listener plugged to a router.
+
+  Usage:
+
+  ```
+  defmodule MyApp.Endpoint do
+    use Sleeky.Endpoint,
+      otp_app: :my_app,
+      router: MyApp.Router
+  end
+  ```
+
+  All options supported by Bandit can be provided via config, eg:
+
+  ```
+  config :my_app, MyApp.Endpoint,
+    scheme: :http,
+    port: 8080
+  ```
+  """
+
+  defmacro __using__(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+    router = Keyword.fetch!(opts, :router)
+
+    quote do
+      @doc false
+      def child_spec(_) do
+        Supervisor.child_spec(
+          {Bandit,
+           unquote(otp_app)
+           |> Application.fetch_env!(__MODULE__)
+           |> Keyword.put(:plug, unquote(router))},
+          []
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#  Description

Simplifies the setup of a bandit endpoint with a new `Sleeky.Endpoint` macro.

Other changes:

* Docs
* Pull sleeky from git in the boilerplate installer, for now