### PR TITLE
Endpoint test configuration in boilerplate

### DIFF
--- a/installer/lib/mix/tasks/new.ex
+++ b/installer/lib/mix/tasks/new.ex
@@ -563,7 +563,7 @@ defmodule Mix.Tasks.Sleeky.New do
     url: "postgres://<%= @app %>:<%= @app %>@localhost/<%= @app %>_test",
     pool: Ecto.Adapters.SQL.Sandbox
 
-  config :<%= @app %>, <%= @mod %>.Port,
+  config :<%= @app %>, <%= @mod %>.Endpoint,
     scheme: :http,
     port: 8079
   """)


### PR DESCRIPTION
# Description

Fix the endpoint configuration for tests in the boilerplate installer, which was a left over from #1 .
