### PR TITLE
Resolve templates before rendering as markdown

### DIFF
--- a/lib/sleeky/ui/markdown.ex
+++ b/lib/sleeky/ui/markdown.ex
@@ -26,7 +26,7 @@ defmodule Sleeky.Ui.Markdown do
 
   defmodule Dsl do
     @moduledoc false
-    
+
     @doc false
     def locals_without_parens, do: [markdown: :*]
 
@@ -63,7 +63,7 @@ defmodule Sleeky.Ui.Markdown do
         import Sleeky.Ui.Markdown.Resolve
 
         def resolve({:markdown, attrs, [content]}, args) when is_binary(content) do
-          case EarmarkParser.as_ast(content) do
+          case content |> resolve(args) |> EarmarkParser.as_ast() do
             {:ok, ast, []} ->
               {:div, attrs, [definition(ast)]}
 

--- a/test/sleeky/ui/markdown_test.exs
+++ b/test/sleeky/ui/markdown_test.exs
@@ -24,6 +24,14 @@ defmodule Sleeky.Ui.MarkdownTest do
     end
   end
 
+  defmodule TemplatedMarkdownView do
+    use Sleeky.Ui.View
+
+    render do
+      markdown "{{ content.summary }}"
+    end
+  end
+
   describe "ui markdown directive" do
     test "resolves markdown into html" do
       assert {:div, [class: "article"],
@@ -46,6 +54,13 @@ defmodule Sleeky.Ui.MarkdownTest do
     test "supports compact notation" do
       assert {:div, [], [{:p, [], [{:strong, [], ["Sleek"]}, " Elixir applications"]}]} ==
                CompactMarkdownView.resolve()
+    end
+
+    test "supports templating" do
+      assert {:div, [], [{:p, [], ["Some title"]}]} ==
+               TemplatedMarkdownView.resolve(%{
+                 content: %{summary: "Some title"}
+               })
     end
   end
 end


### PR DESCRIPTION
# Description

When rendering markdown, we now resolve the content first. This allows for using dynamic markdown, eg coming from a slot or a liquid template.