### PR TITLE
Ui dsl tags catalog

### DIFF
--- a/lib/sleeky/ui/compound.ex
+++ b/lib/sleeky/ui/compound.ex
@@ -55,6 +55,9 @@ defmodule Sleeky.Ui.Compound do
     @doc false
     def locals_without_parens, do: [view: :*, slot: :*]
 
+    @doc false
+    def tags, do: [:view, :slot]
+
     defmacro __using__(_opts) do
       quote do
         import Sleeky.Ui.Compound.Dsl

--- a/lib/sleeky/ui/dsl.ex
+++ b/lib/sleeky/ui/dsl.ex
@@ -15,6 +15,14 @@ defmodule Sleeky.Ui.Dsl do
       Sleeky.Ui.Markdown.Dsl.locals_without_parens()
   end
 
+  @doc false
+  def tags do
+    Sleeky.Ui.Html.Dsl.tags() ++
+      Sleeky.Ui.Compound.Dsl.tags() ++
+      Sleeky.Ui.Each.Dsl.tags() ++
+      Sleeky.Ui.Markdown.Dsl.tags()
+  end
+
   defmacro view({:__aliases__, _, mod}, opts \\ []) do
     ui = __CALLER__.module
     view = module(mod)

--- a/lib/sleeky/ui/each.ex
+++ b/lib/sleeky/ui/each.ex
@@ -39,9 +39,12 @@ defmodule Sleeky.Ui.Each do
 
   defmodule Dsl do
     @moduledoc false
-    
+
     @doc false
     def locals_without_parens, do: [each: :*]
+
+    @doc false
+    def tags, do: [:each]
 
     defmacro __using__(_opts) do
       quote do

--- a/lib/sleeky/ui/html.ex
+++ b/lib/sleeky/ui/html.ex
@@ -132,6 +132,9 @@ defmodule Sleeky.Ui.Html do
     @doc false
     def locals_without_parens, do: Enum.map(@tags, &{&1, :*})
 
+    @doc false
+    def tags, do: @tags
+
     for tag <- @tags do
       defmacro unquote(tag)(attrs, do: {:__block__, _, children}) do
         {:el, [line: 1], [unquote(tag), attrs, children]}

--- a/lib/sleeky/ui/markdown.ex
+++ b/lib/sleeky/ui/markdown.ex
@@ -26,9 +26,12 @@ defmodule Sleeky.Ui.Markdown do
 
   defmodule Dsl do
     @moduledoc false
-    
+
     @doc false
     def locals_without_parens, do: [markdown: :*]
+
+    @doc false
+    def tags, do: [:markdown]
 
     defmacro __using__(_opts) do
       quote do


### PR DESCRIPTION
# Description

Adds a new `Sleeky.Ui.Dsl.tags/0` that returns the complete list of UI tags supported by Sleeky.