### PR TITLE
Request logger

### DIFF
--- a/lib/sleeky/endpoint/generator/router.ex
+++ b/lib/sleeky/endpoint/generator/router.ex
@@ -23,6 +23,7 @@ defmodule Sleeky.Endpoint.Generator.Router do
       defmodule unquote(router_module) do
         use Plug.Router
 
+        plug Sleeky.Plug.Logger
         plug(Plug.Static, at: "/assets", from: {unquote(otp_app), "priv/assets"})
         plug(:match)
         plug(:dispatch)

--- a/lib/sleeky/plug/logger.ex
+++ b/lib/sleeky/plug/logger.ex
@@ -1,0 +1,44 @@
+defmodule Sleeky.Plug.Logger do
+  @moduledoc false
+  @behaviour Plug
+
+  alias Plug.Conn
+  require Logger
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    start = System.monotonic_time()
+
+    Conn.register_before_send(conn, fn conn ->
+      status = conn.status
+      level = if status >= 500, do: :error, else: :info
+
+      Logger.log(level, fn ->
+        stop = System.monotonic_time()
+        ms = System.convert_time_unit(stop - start, :native, :millisecond) |> Integer.to_string()
+        status = Integer.to_string(status)
+
+        [
+          connection_type(conn),
+          ?\s,
+          conn.method,
+          ?\s,
+          conn.request_path,
+          ?\s,
+          status,
+          " in ",
+          ms,
+          "ms"
+        ]
+      end)
+
+      conn
+    end)
+  end
+
+  defp connection_type(%{state: :set_chunked}), do: "Chunked"
+  defp connection_type(_), do: "Sent"
+end


### PR DESCRIPTION
# Description

Adds a custom request logger, heavily based on Plug.Logger, except that it logs a single line per request, and it only logs durations in milliseconds:

```
iex(1)> 21:19:07.344 [info] Migrations already up: 
21:19:10.294 [info] Sent GET / 200 in 1ms: 
21:19:13.592 [info] Sent GET / 200 in 0ms: 
21:19:15.546 [info] Sent GET / 200 in 0ms: 
21:19:17.435 [info] Sent GET / 200 in 0ms: 
21:19:31.655 [info] Sent GET /api/accounts/users 200 in 50ms: 
21:19:37.542 [info] Sent GET /api/accounts/users 200 in 5ms: 
21:19:39.939 [info] Sent GET /api/accounts/users 200 in 1ms: 
21:19:41.194 [info] Sent GET /api/accounts/users 200 in 9ms: 
21:19:43.583 [info] Sent GET /api/accounts/users 200 in 1ms: 
21:20:31.053 [info] Sent GET /api/accounts/users 200 in 2ms: 
21:20:33.099 [info] Sent GET /api/accounts/users 200 in 4ms: 
```