### PR TITLE
Scope api and query builder improvements

### DIFF
--- a/lib/sleeky.ex
+++ b/lib/sleeky.ex
@@ -1,5 +1,9 @@
 defmodule Sleeky do
-  @moduledoc false
+  @moduledoc """
+  The `Sleeky` module aggregates and provides common utility functions for handling DSLs (Domain Specific Languages)
+  within the Sleeky application. It collects various DSL modules and offers functions to manage their local functions
+  and tags.
+  """
 
   @dsls [
     Sleeky.Authorization.Dsl,
@@ -12,10 +16,14 @@ defmodule Sleeky do
     Sleeky.Ui.Dsl
   ]
 
-  @doc false
+  @doc """
+  Returns a sorted list of local functions without parentheses from all the DSL modules.
+  """
   def locals_without_parens,
     do: @dsls |> Enum.flat_map(& &1.locals_without_parens()) |> Enum.sort()
 
-  @doc false
+  @doc """
+  Returns a flat list of tags from all the DSL modules.
+  """
   def tags, do: Enum.flat_map(@dsls, & &1.tags())
 end

--- a/lib/sleeky/authorization/dsl.ex
+++ b/lib/sleeky/authorization/dsl.ex
@@ -5,12 +5,15 @@ defmodule Sleeky.Authorization.Dsl do
     root: Sleeky.Authorization.Dsl.Authorization,
     tags: [
       Sleeky.Authorization.Dsl.Eq,
+      Sleeky.Authorization.Dsl.Same,
+      Sleeky.Authorization.Dsl.Member,
       Sleeky.Authorization.Dsl.Path,
       Sleeky.Authorization.Dsl.Roles,
       Sleeky.Authorization.Dsl.Scope,
       Sleeky.Authorization.Dsl.One,
       Sleeky.Authorization.Dsl.All,
       Sleeky.Authorization.Dsl.NotNil,
-      Sleeky.Authorization.Dsl.IsTrue
+      Sleeky.Authorization.Dsl.IsTrue,
+      Sleeky.Authorization.Dsl.IsFalse
     ]
 end

--- a/lib/sleeky/authorization/dsl/is_false.ex
+++ b/lib/sleeky/authorization/dsl/is_false.ex
@@ -1,0 +1,8 @@
+defmodule Sleeky.Authorization.Dsl.IsFalse do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :any, min: 1, max: 1
+  end
+end

--- a/lib/sleeky/authorization/dsl/member.ex
+++ b/lib/sleeky/authorization/dsl/member.ex
@@ -1,0 +1,8 @@
+defmodule Sleeky.Authorization.Dsl.Member do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :any, min: 2, max: 2
+  end
+end

--- a/lib/sleeky/authorization/dsl/same.ex
+++ b/lib/sleeky/authorization/dsl/same.ex
@@ -1,0 +1,8 @@
+defmodule Sleeky.Authorization.Dsl.Same do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :any, min: 2, max: 2
+  end
+end

--- a/lib/sleeky/authorization/dsl/scope.ex
+++ b/lib/sleeky/authorization/dsl/scope.ex
@@ -10,5 +10,8 @@ defmodule Sleeky.Authorization.Dsl.Scope do
     child :all, min: 0, max: 1
     child :not_nil, min: 0, max: 1
     child :is_true, min: 0, max: 1
+    child :is_false, min: 0, max: 1
+    child :member, min: 0, max: 1
+    child :same, min: 0, max: 1
   end
 end

--- a/lib/sleeky/authorization/parser.ex
+++ b/lib/sleeky/authorization/parser.ex
@@ -84,8 +84,20 @@ defmodule Sleeky.Authorization.Parser do
     %Expression{op: :neq, args: [arg, {:value, nil}]}
   end
 
+  defp translate_expression(:same, args) do
+    %Expression{op: :eq, args: args}
+  end
+
+  defp translate_expression(:member, args) do
+    %Expression{op: :in, args: args}
+  end
+
   defp translate_expression(:is_true, [arg]) do
     %Expression{op: :eq, args: [arg, {:value, true}]}
+  end
+
+  defp translate_expression(:is_false, [arg]) do
+    %Expression{op: :eq, args: [arg, {:value, false}]}
   end
 
   defp translate_expression(op, args), do: %Expression{op: op, args: args}

--- a/lib/sleeky/query_builder.ex
+++ b/lib/sleeky/query_builder.ex
@@ -125,7 +125,9 @@ defmodule Sleeky.QueryBuilder do
   def join(query, nil), do: query
 
   def join(query, joins) when is_list(joins) do
-    Enum.reduce(joins, query, fn
+    joins
+    |> Enum.uniq()
+    |> Enum.reduce(query, fn
       {join_type, {remote_model, remote_alias, remote_column}, {local_alias, local_column}},
       query ->
         join_type =
@@ -146,7 +148,7 @@ defmodule Sleeky.QueryBuilder do
   """
   def combine(builders, op) do
     %__MODULE__{
-      joins: Enum.flat_map(builders, & &1.joins),
+      joins: builders |> Enum.flat_map(& &1.joins) |> Enum.uniq(),
       filters: [{op, Enum.flat_map(builders, & &1.filters)}]
     }
   end

--- a/test/sleeky/authorization/query_test.exs
+++ b/test/sleeky/authorization/query_test.exs
@@ -198,7 +198,6 @@ defmodule Sleeky.Authorization.QueryTest do
                {:join, {Blogs.Publishing.Post, :comment_post, :id}, {:comment, :post_id}},
                {:join, {Blogs.Publishing.Author, :comment_post_author, :id},
                 {:comment_post, :author_id}},
-               {:join, {Blogs.Publishing.Post, :comment_post, :id}, {:comment, :post_id}},
                {:join, {Blogs.Publishing.Blog, :comment_post_blog, :id},
                 {:comment_post, :blog_id}},
                {:join, {Blogs.Publishing.Author, :comment_post_blog_author, :id},

--- a/test/support/blogs/authorization.ex
+++ b/test/support/blogs/authorization.ex
@@ -4,7 +4,7 @@ defmodule Blogs.Authorization do
 
   authorization roles: "current_user.roles" do
     scope :author do
-      eq do
+      same do
         path "**.author"
         path "current_user"
       end
@@ -17,7 +17,7 @@ defmodule Blogs.Authorization do
     end
 
     scope :self do
-      eq do
+      same do
         path "user.id"
         path "current_user.id"
       end
@@ -30,9 +30,8 @@ defmodule Blogs.Authorization do
     end
 
     scope :is_not_locked do
-      eq do
+      is_false do
         path "**.locked"
-        false
       end
     end
 


### PR DESCRIPTION
# Description

* Add `same`, `member` and `is_false` to the scope dsl
* Query builder no longer builds duplicate joins in queries. 