### PR TITLE
Preload parents in jobs

### DIFF
--- a/lib/sleeky/job.ex
+++ b/lib/sleeky/job.ex
@@ -30,7 +30,9 @@ defmodule Sleeky.Job do
   end
 
   defp do_perform(job, model, id, task) do
-    case id |> model.fetch!() |> task.execute() do
+    opts = [preload: model.parent_field_names()]
+
+    case id |> model.fetch!(opts) |> task.execute() do
       {:error, reason} -> handle_error(job, model, id, task, reason)
       _ -> :ok
     end

--- a/lib/sleeky/model/generator/fetch_function.ex
+++ b/lib/sleeky/model/generator/fetch_function.ex
@@ -6,18 +6,17 @@ defmodule Sleeky.Model.Generator.FetchFunction do
   @impl true
   def generate(model, _),
     do: [
-      fetch_function(model),
+      fetch_function(),
       fetch_bang_function(),
       fetch_by_unique_key_functions(model)
     ]
 
-  defp fetch_function(model) do
+  defp fetch_function do
     quote do
       def fetch(id, opts \\ []) do
-        repo = unquote(model.context).repo()
         preload = Keyword.get(opts, :preload, [])
 
-        case __MODULE__ |> repo.get(id) |> repo.preload(preload) do
+        case __MODULE__ |> @repo.get(id) |> @repo.preload(preload) do
           nil -> {:error, :not_found}
           model -> {:ok, model}
         end

--- a/lib/sleeky/model/generator/metadata.ex
+++ b/lib/sleeky/model/generator/metadata.ex
@@ -14,11 +14,14 @@ defmodule Sleeky.Model.Generator.Metadata do
     actions = model.actions
     keys = model.keys
 
+    parent_field_names = Enum.map(parents, & &1.name)
+
     quote do
       @repo unquote(model.repo)
 
       @attributes unquote(Macro.escape(attributes))
       @parents unquote(Macro.escape(parents))
+      @parent_field_names unquote(parent_field_names)
       @children unquote(Macro.escape(children))
       @fields unquote(Macro.escape(fields))
       @string_fields unquote(Macro.escape(string_fields))
@@ -39,6 +42,8 @@ defmodule Sleeky.Model.Generator.Metadata do
       def keys, do: @keys
       def fields, do: @fields
       def actions, do: @actions
+
+      def parent_field_names, do: @parent_field_names
 
       def field(name) when is_atom(name) do
         case Map.get(@fields, name) do

--- a/test/sleeky/job_test.exs
+++ b/test/sleeky/job_test.exs
@@ -1,0 +1,21 @@
+defmodule Sleeky.JobTest do
+  use Sleeky.DataCase
+
+  alias Blogs.Publishing.Blog
+  alias Sleeky.Job
+
+  setup [:comments]
+
+  describe "perform/1" do
+    test "preloads models", %{blog: blog} do
+      defmodule BlogTask do
+        def execute(blog) do
+          assert blog.author
+        end
+      end
+
+      args = %{"model" => Blog, "id" => blog.id, "task" => BlogTask}
+      assert :ok == Job.perform(%Oban.Job{args: args})
+    end
+  end
+end


### PR DESCRIPTION
# Description

When fetching a model, preload its parents, just before passing iit to the task. This is for convenience, so that the task implementation has enough context already available. 