### PR TITLE
More convenient model create many function

### DIFF
--- a/lib/sleeky/model.ex
+++ b/lib/sleeky/model.ex
@@ -8,6 +8,7 @@ defmodule Sleeky.Model do
     generators: [
       Sleeky.Model.Generator.Metadata,
       Sleeky.Model.Generator.EctoSchema,
+      Sleeky.Model.Generator.Helpers,
       Sleeky.Model.Generator.FieldNames,
       Sleeky.Model.Generator.Changesets,
       Sleeky.Model.Generator.CreateFunction,

--- a/lib/sleeky/model/generator/create_function.ex
+++ b/lib/sleeky/model/generator/create_function.ex
@@ -34,6 +34,17 @@ defmodule Sleeky.Model.Generator.CreateFunction do
   defp batch_fun(model) do
     quote do
       def create_many(items, opts \\ []) when is_list(items) do
+        now = DateTime.utc_now()
+
+        items =
+          for item <- items do
+            item
+            |> atom_keys()
+            |> Map.put_new_lazy(:id, &Ecto.UUID.generate/0)
+            |> Map.put_new(:inserted_at, now)
+            |> Map.put_new(:updated_at, now)
+          end
+
         unquote(model.context).repo().insert_all(__MODULE__, items, opts)
 
         :ok

--- a/lib/sleeky/model/generator/helpers.ex
+++ b/lib/sleeky/model/generator/helpers.ex
@@ -1,0 +1,11 @@
+defmodule Sleeky.Model.Generator.Helpers do
+  @moduledoc false
+  @behaviour Diesel.Generator
+
+  @impl true
+  def generate(_model, _) do
+    quote do
+      import Sleeky.Model.Helpers
+    end
+  end
+end

--- a/lib/sleeky/model/helpers.ex
+++ b/lib/sleeky/model/helpers.ex
@@ -1,0 +1,12 @@
+defmodule Sleeky.Model.Helpers do
+  @moduledoc false
+
+  def atom_keys(map) when is_map(map) do
+    map
+    |> Enum.map(fn
+      {key, value} when is_atom(key) -> {key, value}
+      {key, value} when is_binary(key) -> {String.to_existing_atom(key), value}
+    end)
+    |> Enum.into(%{})
+  end
+end

--- a/test/sleeky/model/create_test.exs
+++ b/test/sleeky/model/create_test.exs
@@ -25,4 +25,12 @@ defmodule Sleeky.Model.CreateTest do
       assert errors_on(changeset) == %{name: ["is invalid"]}
     end
   end
+
+  describe "create_many/2" do
+    test "creates many models at once" do
+      authors = [%{name: "a1", profile: "publisher"}, %{name: "a2", profile: "publisher"}]
+
+      assert :ok = Author.create_many(authors)
+    end
+  end
 end


### PR DESCRIPTION
# Description

A more convenient api to the `create_many/2` model function, so that ids and timestamps are auto-generated if not specified. 