### PR TITLE
Support text attributes

### DIFF
--- a/lib/sleeky/job.ex
+++ b/lib/sleeky/job.ex
@@ -52,16 +52,19 @@ defmodule Sleeky.Job do
     {:error, reason}
   end
 
-  defp log_error(job, model, id, task, reason),
-    do:
-      Logger.warning("task failed",
-        task: task,
-        model: model,
-        id: id,
-        queue: job.queue,
-        reason: format_error(reason),
-        attempts_left: job.max_attempts - job.attempt
-      )
+  defp log_error(job, model, id, task, reason) do
+    attempts_left = job.max_attempts - job.attempt
+    level = if attempts_left == 0, do: :error, else: :warning
+
+    Logger.log(level, "task failed",
+      task: task,
+      model: model,
+      id: id,
+      queue: job.queue,
+      reason: format_error(reason),
+      attempts_left: attempts_left
+    )
+  end
 
   defp format_error(%Ecto.Changeset{} = changeset) do
     changeset

--- a/lib/sleeky/model.ex
+++ b/lib/sleeky/model.ex
@@ -51,6 +51,7 @@ defmodule Sleeky.Model do
     defstruct [
       :name,
       :kind,
+      :ecto_type,
       :storage,
       :default,
       :enum,

--- a/lib/sleeky/model/dsl/attribute.ex
+++ b/lib/sleeky/model/dsl/attribute.ex
@@ -7,7 +7,7 @@ defmodule Sleeky.Model.Dsl.Attribute do
 
     attribute :kind,
       kind: :atom,
-      in: [:integer, :float, :decimal, :string, :boolean, :timestamp, :date],
+      in: [:integer, :float, :decimal, :string, :boolean, :timestamp, :date, :text],
       required: true
 
     attribute :required, kind: :boolean, required: false, default: true

--- a/lib/sleeky/model/generator/ecto_schema.ex
+++ b/lib/sleeky/model/generator/ecto_schema.ex
@@ -55,17 +55,17 @@ defmodule Sleeky.Model.Generator.EctoSchema do
 
     for attr <- attrs do
       name = attr.name
-      storage = attr.storage
+      type = attr.ecto_type
 
       case attr.default do
         nil ->
           quote do
-            field(unquote(name), unquote(storage))
+            field(unquote(name), unquote(type))
           end
 
         default ->
           quote do
-            field(unquote(name), unquote(storage), default: unquote(default))
+            field(unquote(name), unquote(type), default: unquote(default))
           end
       end
     end

--- a/lib/sleeky/model/parser.ex
+++ b/lib/sleeky/model/parser.ex
@@ -43,6 +43,7 @@ defmodule Sleeky.Model.Parser do
       for {:attribute, opts, _} <- definition do
         attr_name = Keyword.fetch!(opts, :name)
         kind = Keyword.fetch!(opts, :kind)
+        ecto_type = ecto_type(kind)
         storage = storage(kind)
         required = Keyword.get(opts, :required, true)
         allowed_values = Keyword.get(opts, :in, [])
@@ -54,6 +55,7 @@ defmodule Sleeky.Model.Parser do
           name: attr_name,
           column_name: attr_name,
           kind: kind,
+          ecto_type: ecto_type,
           storage: storage,
           aliases: [attr_name],
           required?: required,
@@ -235,7 +237,11 @@ defmodule Sleeky.Model.Parser do
 
   defp storage(:id), do: :binary_id
   defp storage(:timestamp), do: :utc_datetime
+  defp storage(:text), do: :text
   defp storage(kind), do: kind
+
+  defp ecto_type(:text), do: :string
+  defp ecto_type(kind), do: kind
 
   @primary_key %Attribute{
     name: :id,


### PR DESCRIPTION
# Description

Adds support for attributes of type `text`. 

Also, unrelated, when executing background jobs, log failures on last attempts at error level.