### PR TITLE
Group domain models

### DIFF
--- a/lib/sleeky/domain/dsl.ex
+++ b/lib/sleeky/domain/dsl.ex
@@ -4,7 +4,7 @@ defmodule Sleeky.Domain.Dsl do
     otp_app: :sleeky,
     root: Sleeky.Domain.Dsl.Domain,
     tags: [
-      Sleeky.Domain.Dsl.Model,
+      Sleeky.Domain.Dsl.Models,
       Sleeky.Domain.Dsl.Scopes
     ]
 end

--- a/lib/sleeky/domain/dsl/domain.ex
+++ b/lib/sleeky/domain/dsl/domain.ex
@@ -3,7 +3,7 @@ defmodule Sleeky.Domain.Dsl.Domain do
   use Diesel.Tag
 
   tag do
-    child :model, min: 1
+    child :models, min: 1, max: 1
     child :scopes, min: 0, max: 1
   end
 end

--- a/lib/sleeky/domain/dsl/model.ex
+++ b/lib/sleeky/domain/dsl/model.ex
@@ -1,8 +1,0 @@
-defmodule Sleeky.Domain.Dsl.Model do
-  @moduledoc false
-  use Diesel.Tag
-
-  tag do
-    child kind: :module, min: 1, max: 1
-  end
-end

--- a/lib/sleeky/domain/dsl/models.ex
+++ b/lib/sleeky/domain/dsl/models.ex
@@ -1,0 +1,8 @@
+defmodule Sleeky.Domain.Dsl.Models do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :module, min: 1
+  end
+end

--- a/lib/sleeky/domain/parser.ex
+++ b/lib/sleeky/domain/parser.ex
@@ -18,7 +18,8 @@ defmodule Sleeky.Domain.Parser do
   end
 
   defp with_models(context, children) do
-    models = for {:model, _, [model]} <- children, do: model
+    models = for {:models, _, models} <- children, do: models
+    models = List.flatten(models)
 
     %{context | models: models}
   end


### PR DESCRIPTION
# Description

When listing models under a domain, rather than defining each model separately, we group all models. 

Old way:

```elixir
model Model1
model Model2
```

New way:

```elixir
models do 
  Model1
  Model2
end
```
