### PR TITLE
Simpler DSL for UI routes

### DIFF
--- a/lib/sleeky/ui/route/dsl.ex
+++ b/lib/sleeky/ui/route/dsl.ex
@@ -4,7 +4,6 @@ defmodule Sleeky.Ui.Route.Dsl do
     otp_app: :sleeky,
     root: Sleeky.Ui.Route.Dsl.Route,
     tags: [
-      Sleeky.Ui.Route.Dsl.Action,
       Sleeky.Ui.Route.Dsl.View
     ]
 end

--- a/lib/sleeky/ui/route/dsl/action.ex
+++ b/lib/sleeky/ui/route/dsl/action.ex
@@ -1,8 +1,0 @@
-defmodule Sleeky.Ui.Route.Dsl.Action do
-  @moduledoc false
-  use Diesel.Tag
-
-  tag do
-    child kind: :module, min: 1, max: 1
-  end
-end

--- a/lib/sleeky/ui/route/dsl/route.ex
+++ b/lib/sleeky/ui/route/dsl/route.ex
@@ -5,7 +5,7 @@ defmodule Sleeky.Ui.Route.Dsl.Route do
   tag do
     attribute :method, kind: :string, default: "get", in: ["get", "post", "put", "delete"]
     attribute :name, kind: :string
-    child :action, min: 0, max: 1
+    attribute :action, kind: :module, required: false
     child :view, min: 0
   end
 end

--- a/lib/sleeky/ui/route/dsl/view.ex
+++ b/lib/sleeky/ui/route/dsl/view.ex
@@ -3,7 +3,8 @@ defmodule Sleeky.Ui.Route.Dsl.View do
   use Diesel.Tag
 
   tag do
-    attribute :name, kind: :string, required: false, default: "default"
-    child kind: :module, min: 1, max: 1
+    attribute :name, kind: :module, required: false
+    attribute :for, kind: :string, required: false, default: "default"
+    child kind: :module, min: 0, max: 1
   end
 end

--- a/test/sleeky/domain/list_action_test.exs
+++ b/test/sleeky/domain/list_action_test.exs
@@ -41,5 +41,15 @@ defmodule Sleeky.Domain.ListActionTest do
       assert [c] = page.entries
       assert c == context.comment1
     end
+
+    test "supports sorting", context do
+      params = Map.put(context.params, :sort, inserted_at: :asc)
+      assert page = Publishing.list_comments(params)
+      assert [c1, c2, c3] = page.entries
+
+      params = Map.put(context.params, :sort, inserted_at: :desc)
+      assert page = Publishing.list_comments(params)
+      assert [^c3, ^c2, ^c1] = page.entries
+    end
   end
 end


### PR DESCRIPTION
# Description

Simplifies the way routes are defined. 

Actions are now defined as an attribute, and it is possible to declare just the action without the need to declare the views, and viceversa. Sensible defaults based on naming will be used when user doesn't specify anything. 